### PR TITLE
Fix participant state machines after activation failures

### DIFF
--- a/rsb-java/src/main/java/rsb/Informer.java
+++ b/rsb-java/src/main/java/rsb/Informer.java
@@ -115,17 +115,14 @@ public class Informer<DataType extends Object> extends Participant {
 
         @Override
         public void activate() throws RSBException {
+            Informer.super.activate();
+            Informer.this.router.activate();
             Informer.this.state = new StateActive();
             LOG.log(Level.FINE,
                     "Informer activated: [Scope={0}, Type={1}]",
                     new Object[] { Informer.this.getScope(),
                             Informer.this.type.getName() });
-            try {
-                Informer.this.router.activate();
-            } catch (final RSBException e) {
-                throw new InitializeException(e);
-            }
-            Informer.super.activate();
+            Informer.this.activated();
         }
 
         @Override

--- a/rsb-java/src/main/java/rsb/Listener.java
+++ b/rsb-java/src/main/java/rsb/Listener.java
@@ -119,9 +119,10 @@ public class Listener extends Participant {
 
         @Override
         public void activate() throws RSBException {
+            Listener.super.activate();
             Listener.this.getRouter().activate();
             Listener.this.state = new StateActive();
-            Listener.super.activate();
+            Listener.this.activated();
         }
 
         @Override

--- a/rsb-java/src/main/java/rsb/Participant.java
+++ b/rsb-java/src/main/java/rsb/Participant.java
@@ -39,9 +39,10 @@ import rsb.config.ParticipantConfig;
  *
  * Implementing classes need to ensure that {@link #activate()} and
  * {@link #deactivate()} are called in case these methods are overridden. Method
- * {@link #activate()} needs to be called once all required internal details are
- * set up and processing is possible now and {@link #deactivate()} needs to be
- * called before functionality is teared down.
+ * {@link #activate()} has to be called before setting up the active state.
+ * Method {@link #activated()} needs to be called once all required internal
+ * details are set up and processing is possible now and {@link #deactivate()}
+ * needs to be called before functionality is teared down.
  *
  * @author jwienke
  * @author swrede
@@ -84,6 +85,16 @@ public abstract class Participant extends AbstractActivatable {
                             + "and subsequently deactivated once. "
                             + "Multiple cycles are not supported.");
         }
+    }
+
+    /**
+     * Post-activation hook. To be called by subclasses after their activation
+     * has finished and they have effectively entered the active state.
+     *
+     * @throws RSBException
+     *                 activation hook failed
+     */
+    protected void activated() throws RSBException {
         if (this.observerManager != null) {
             this.observerManager.notifyParticipantCreated(this, this.createArgs);
         }

--- a/rsb-java/src/main/java/rsb/patterns/LocalServer.java
+++ b/rsb-java/src/main/java/rsb/patterns/LocalServer.java
@@ -112,10 +112,11 @@ public class LocalServer extends Server<LocalMethod> {
      */
     private void addAndActivate(final String name, final LocalMethod method)
             throws RSBException {
-        addMethod(name, method, false);
+        method.setObserverManager(this.getObserverManager());
         if (this.isActive()) {
             method.activate();
         }
+        addMethod(name, method, false);
     }
 
     /**

--- a/rsb-java/src/main/java/rsb/patterns/Method.java
+++ b/rsb-java/src/main/java/rsb/patterns/Method.java
@@ -104,10 +104,11 @@ public abstract class Method extends Participant {
 
         @Override
         public void activate() throws RSBException {
+            Method.super.activate();
             Method.this.getInformer().activate();
             Method.this.getListener().activate();
-            Method.super.activate();
             Method.this.state = new StateActive();
+            Method.this.activated();
         }
 
         @Override

--- a/rsb-java/src/main/java/rsb/patterns/RemoteServer.java
+++ b/rsb-java/src/main/java/rsb/patterns/RemoteServer.java
@@ -444,13 +444,15 @@ public class RemoteServer extends Server<RemoteMethod> {
                             // dummy type
                         }.setScope(getScope().concat(new Scope("/" + name)))
                                 .setConfig(getConfig()).setParent(this));
-        // it should never be possible that an exception is thrown for a
-        // duplicated method because we take care of this
-        addMethod(name, method, false);
+        method.setObserverManager(this.getObserverManager());
 
         if (this.isActive()) {
             method.activate();
         }
+
+        // it should never be possible that an exception is thrown for a
+        // duplicated method because we take care of this
+        addMethod(name, method, false);
 
         return method;
     }

--- a/rsb-java/src/main/java/rsb/patterns/Server.java
+++ b/rsb-java/src/main/java/rsb/patterns/Server.java
@@ -98,11 +98,12 @@ public abstract class Server<MethodType extends Method> extends Participant {
 
         @Override
         public void activate() throws RSBException {
+            Server.super.activate();
             for (final Method method : Server.this.methods.values()) {
                 method.activate();
             }
-            Server.super.activate();
             Server.this.state = new StateActive();
+            Server.this.activated();
         }
 
         @Override

--- a/rsb-java/src/main/java/rsb/patterns/Server.java
+++ b/rsb-java/src/main/java/rsb/patterns/Server.java
@@ -201,7 +201,6 @@ public abstract class Server<MethodType extends Method> extends Participant {
                 throw new IllegalArgumentException("A method with name " + name
                         + " already exists.");
             }
-            method.setObserverManager(getObserverManager());
             this.methods.put(name, method);
         }
     }

--- a/rsb-java/src/test/java/rsb/InformerStateTest.java
+++ b/rsb-java/src/test/java/rsb/InformerStateTest.java
@@ -27,6 +27,8 @@
  */
 package rsb;
 
+import rsb.config.ParticipantConfig;
+
 /**
  * A {@link ParticipantStateCheck} for {@link Informer} instances.
  *
@@ -36,10 +38,11 @@ package rsb;
 public class InformerStateTest extends ParticipantStateCheck {
 
     @Override
-    protected Participant createParticipant() throws Exception {
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
         return new Informer<String>(new InformerCreateArgs()
                 .setScope(new Scope("/some/scope")).setType(String.class)
-                .setConfig(Utilities.createParticipantConfig()));
+                .setConfig(config));
     }
 
 }

--- a/rsb-java/src/test/java/rsb/ListenerStateTest.java
+++ b/rsb-java/src/test/java/rsb/ListenerStateTest.java
@@ -27,6 +27,8 @@
  */
 package rsb;
 
+import rsb.config.ParticipantConfig;
+
 /**
  * A {@link ParticipantStateCheck} for {@link Listener} instances.
  *
@@ -36,10 +38,10 @@ package rsb;
 public class ListenerStateTest extends ParticipantStateCheck {
 
     @Override
-    protected Participant createParticipant() throws Exception {
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
         return new Listener(new ListenerCreateArgs().setScope(
-                new Scope("/some/scope")).setConfig(
-                Utilities.createParticipantConfig()));
+                new Scope("/some/scope")).setConfig(config));
     }
 
 }

--- a/rsb-java/src/test/java/rsb/ParticipantStateCheck.java
+++ b/rsb-java/src/test/java/rsb/ParticipantStateCheck.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import rsb.config.ParticipantConfig;
 import rsb.converter.DefaultConverters;
 import rsb.transport.DefaultTransports;
 
@@ -49,7 +50,8 @@ public abstract class ParticipantStateCheck extends RsbTestCase {
 
     private Participant participant = null;
 
-    protected abstract Participant createParticipant() throws Exception;
+    protected abstract Participant createParticipant(
+            ParticipantConfig config) throws Exception;
 
     @BeforeClass
     public static void registerConverters() {
@@ -59,7 +61,8 @@ public abstract class ParticipantStateCheck extends RsbTestCase {
 
     @Before
     public void setUp() throws Exception {
-        this.participant = createParticipant();
+        final ParticipantConfig config = Utilities.createParticipantConfig();
+        this.participant = createParticipant(config);
     }
 
     @After

--- a/rsb-java/src/test/java/rsb/ParticipantStateCheck.java
+++ b/rsb-java/src/test/java/rsb/ParticipantStateCheck.java
@@ -114,6 +114,24 @@ public abstract class ParticipantStateCheck extends RsbTestCase {
         this.participant.activate();
     }
 
+    @Test
+    public void inactiveAfterActivationFailure() throws Exception {
+        final ParticipantConfig config =
+                Utilities.createBrokenParticipantConfig();
+        final Participant participant = createParticipant(config);
+        try {
+            participant.activate();
+            // if activation doesn't fail (for instance for remote servers,
+            // which do nothing serious with the transport on activation), we
+            // cannot check this. So, tear down everything and leave the test.
+            participant.deactivate();
+            return;
+        } catch (final RSBException e) {
+            // expected
+        }
+        assertFalse(participant.isActive());
+    }
+
 }
 
 //CHECKSTYLE.ON: JavadocMethod

--- a/rsb-java/src/test/java/rsb/Utilities.java
+++ b/rsb-java/src/test/java/rsb/Utilities.java
@@ -29,6 +29,7 @@ package rsb;
 
 import rsb.config.ParticipantConfig;
 import rsb.config.ParticipantConfigCreator;
+import rsb.config.TransportConfig;
 import rsb.transport.spread.SpreadOptions;
 import rsb.transport.spread.SpreadWrapper;
 import rsb.transport.spread.SpreadWrapperImpl;
@@ -41,6 +42,11 @@ import rsb.util.Properties;
  * @author jwienke
  */
 public final class Utilities {
+
+    private static final String SOCKET_TRANSPORT_CONFIG_KEY = "socket";
+    private static final String SOCKET_TRANSPORT_PORT_KEY =
+            "transport.socket.port";
+    private static final int SOCKET_PORT_OFFSET = 10;
 
     private Utilities() {
         super();
@@ -72,7 +78,8 @@ public final class Utilities {
     public static ParticipantConfig createParticipantConfig() {
 
         final ParticipantConfig config = new ParticipantConfig();
-        config.getOrCreateTransport("socket").setEnabled(true);
+        config.getOrCreateTransport(
+                SOCKET_TRANSPORT_CONFIG_KEY).setEnabled(true);
 
         // handle configuration
         final Properties properties = new Properties();
@@ -81,6 +88,26 @@ public final class Utilities {
 
         return config;
 
+    }
+
+    /**
+     * Creates a participant config that will result in a failure in case a
+     * client tries to use it because the transport will not connect.
+     *
+     * @return a participant configuration that fails connecting
+     */
+    public static ParticipantConfig createBrokenParticipantConfig() {
+        final ParticipantConfig config = Utilities.createParticipantConfig();
+        final TransportConfig socketConfig = config.getOrCreateTransport(
+                SOCKET_TRANSPORT_CONFIG_KEY);
+        socketConfig.getOptions().setProperty(
+                SOCKET_TRANSPORT_PORT_KEY,
+                Integer.toString(
+                    socketConfig.getOptions().getProperty(
+                        SOCKET_TRANSPORT_PORT_KEY).asInteger()
+                    + SOCKET_PORT_OFFSET));
+        socketConfig.getOptions().setProperty("transport.socket.server", "0");
+        return config;
     }
 
 }

--- a/rsb-java/src/test/java/rsb/patterns/LocalMethodStateTest.java
+++ b/rsb-java/src/test/java/rsb/patterns/LocalMethodStateTest.java
@@ -1,0 +1,53 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2018 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb.patterns;
+
+import rsb.Participant;
+import rsb.ParticipantCreateArgs;
+import rsb.ParticipantStateCheck;
+import rsb.Scope;
+import rsb.config.ParticipantConfig;
+
+/**
+ * A {@link ParticipantStateCheck} for {@link LocalMethod} instances.
+ *
+ * @author jwienke
+ */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public class LocalMethodStateTest extends ParticipantStateCheck {
+
+    @Override
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
+        return new LocalMethod(
+                new ParticipantCreateArgs<ParticipantCreateArgs<?>>() {
+                    // dummy type
+                }.setScope(new Scope("/localmethodtest")).setConfig(config), null);
+    }
+
+}

--- a/rsb-java/src/test/java/rsb/patterns/LocalServerStateTest.java
+++ b/rsb-java/src/test/java/rsb/patterns/LocalServerStateTest.java
@@ -31,7 +31,7 @@ import rsb.LocalServerCreateArgs;
 import rsb.Participant;
 import rsb.ParticipantStateCheck;
 import rsb.Scope;
-import rsb.Utilities;
+import rsb.config.ParticipantConfig;
 
 /**
  * A {@link ParticipantStateCheck} for {@link LocalServer} instances.
@@ -42,10 +42,10 @@ import rsb.Utilities;
 public class LocalServerStateTest extends ParticipantStateCheck {
 
     @Override
-    protected Participant createParticipant() throws Exception {
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
         return new LocalServer(new LocalServerCreateArgs().setScope(
-                new Scope("/some/scope")).setConfig(
-                Utilities.createParticipantConfig()));
+                new Scope("/some/scope")).setConfig(config));
     }
 
 }

--- a/rsb-java/src/test/java/rsb/patterns/RemoteMethodStateTest.java
+++ b/rsb-java/src/test/java/rsb/patterns/RemoteMethodStateTest.java
@@ -1,0 +1,54 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2018 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb.patterns;
+
+import rsb.Participant;
+import rsb.ParticipantCreateArgs;
+import rsb.ParticipantStateCheck;
+import rsb.Scope;
+import rsb.config.ParticipantConfig;
+
+/**
+ * A {@link ParticipantStateCheck} for {@link LocalMethod} instances.
+ *
+ * @author jwienke
+ */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public class RemoteMethodStateTest extends ParticipantStateCheck {
+
+    @Override
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
+        return new RemoteMethod(
+                new ParticipantCreateArgs<ParticipantCreateArgs<?>>() {
+                    // dummy type
+                }.setScope(new Scope("/remotemethodtest")).setConfig(config));
+    }
+
+}
+

--- a/rsb-java/src/test/java/rsb/patterns/RemoteServerStateTest.java
+++ b/rsb-java/src/test/java/rsb/patterns/RemoteServerStateTest.java
@@ -27,10 +27,15 @@
  */
 package rsb.patterns;
 
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
 import rsb.Participant;
 import rsb.ParticipantStateCheck;
 import rsb.RemoteServerCreateArgs;
 import rsb.Scope;
+import rsb.Utilities;
 import rsb.config.ParticipantConfig;
 
 /**
@@ -46,6 +51,33 @@ public class RemoteServerStateTest extends ParticipantStateCheck {
             final ParticipantConfig config) throws Exception {
         return new RemoteServer(new RemoteServerCreateArgs().setScope(
                 new Scope("/some/scope")).setConfig(config));
+    }
+
+    /**
+     * Checks that deactivation is successful even after a failed call to a
+     * previously uncalled method.
+     *
+     * @throws Exception
+     *             test error
+     */
+    @Test
+    public void deactivationAfterNewMethodFailure() throws Exception {
+        final RemoteServer server = (RemoteServer) createParticipant(
+                Utilities.createBrokenParticipantConfig());
+        server.activate();
+        try {
+            server.call("failingmethod");
+            // The previous call must fail as it is the first one to create
+            // actual participants that interact with the transport.
+            fail("Calling a method with a broken transport configuration "
+                    + "must fail");
+            // We cannot use the junit annotation for expected exceptions here
+            // as also deactivate can raise the same exception type.
+        } catch (final Exception e) {
+            // expected here
+        }
+        // this must still succeed
+        server.deactivate();
     }
 
 }

--- a/rsb-java/src/test/java/rsb/patterns/RemoteServerStateTest.java
+++ b/rsb-java/src/test/java/rsb/patterns/RemoteServerStateTest.java
@@ -31,7 +31,7 @@ import rsb.Participant;
 import rsb.ParticipantStateCheck;
 import rsb.RemoteServerCreateArgs;
 import rsb.Scope;
-import rsb.Utilities;
+import rsb.config.ParticipantConfig;
 
 /**
  * A {@link ParticipantStateCheck} for {@link RemoteServer} instances.
@@ -42,10 +42,10 @@ import rsb.Utilities;
 public class RemoteServerStateTest extends ParticipantStateCheck {
 
     @Override
-    protected Participant createParticipant() throws Exception {
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
         return new RemoteServer(new RemoteServerCreateArgs().setScope(
-                new Scope("/some/scope")).setConfig(
-                Utilities.createParticipantConfig()));
+                new Scope("/some/scope")).setConfig(config));
     }
 
 }


### PR DESCRIPTION
Fixes a few issues regarding the state machine implementation of participants in case activations failed. Should at least partially resolve https://code.cor-lab.org/issues/2775