### PR TITLE
Make handlers interruptible

### DIFF
--- a/rsb-java/src/main/java/rsb/AbstractDataHandler.java
+++ b/rsb-java/src/main/java/rsb/AbstractDataHandler.java
@@ -45,7 +45,7 @@ public abstract class AbstractDataHandler<DataType> implements Handler {
 
     @SuppressWarnings({ "unchecked", "PMD.AvoidCatchingGenericException" })
     @Override
-    public void internalNotify(final Event event) {
+    public void internalNotify(final Event event) throws InterruptedException {
         try {
             this.handleEvent((DataType) event.getData());
         } catch (final RuntimeException ex) {
@@ -60,7 +60,9 @@ public abstract class AbstractDataHandler<DataType> implements Handler {
      *
      * @param data
      *            data contained in the event to handle
+     * @throws InterruptedException
+     *             Execution of the handler operation was interrupted
      */
-    public abstract void handleEvent(DataType data);
+    public abstract void handleEvent(DataType data) throws InterruptedException;
 
 }

--- a/rsb-java/src/main/java/rsb/AbstractEventHandler.java
+++ b/rsb-java/src/main/java/rsb/AbstractEventHandler.java
@@ -37,16 +37,18 @@ package rsb;
 public abstract class AbstractEventHandler implements Handler {
 
     @Override
-    public void internalNotify(final Event event) {
+    public void internalNotify(final Event event) throws InterruptedException {
         this.handleEvent(event);
-    };
+    }
 
     /**
      * Shall implement the real handling logic for an event.
      *
      * @param event
      *            the event to handle
+     * @throws InterruptedException
+     *             Execution of the handler operation was interrupted
      */
-    public abstract void handleEvent(Event event);
+    public abstract void handleEvent(Event event) throws InterruptedException;
 
 }

--- a/rsb-java/src/main/java/rsb/FilteringHandler.java
+++ b/rsb-java/src/main/java/rsb/FilteringHandler.java
@@ -72,7 +72,7 @@ public class FilteringHandler implements Handler {
     }
 
     @Override
-    public void internalNotify(final Event event) {
+    public void internalNotify(final Event event) throws InterruptedException {
         for (final Filter filter : this.filters) {
             if (!filter.match(event)) {
                 return;

--- a/rsb-java/src/main/java/rsb/Handler.java
+++ b/rsb-java/src/main/java/rsb/Handler.java
@@ -42,7 +42,9 @@ public interface Handler extends EventListener {
      *
      * @param event
      *            the received event the handler should process
+     * @throws InterruptedException
+     *             Execution of the handler operation was interrupted
      */
-    void internalNotify(Event event);
+    void internalNotify(Event event) throws InterruptedException;
 
 }

--- a/rsb-java/src/main/java/rsb/eventprocessing/MatchAndDispatchTask.java
+++ b/rsb-java/src/main/java/rsb/eventprocessing/MatchAndDispatchTask.java
@@ -81,6 +81,10 @@ public class MatchAndDispatchTask implements Callable<Boolean> {
             if (this.match(this.event)) {
                 try {
                     this.handler.internalNotify(this.event);
+                } catch (final InterruptedException e) {
+                    LOG.warning("Interrupted while calling handler");
+                    // restore interruption state
+                    Thread.currentThread().interrupt();
                 } catch (final RuntimeException e) {
                     LOG.log(Level.WARNING,
                             "Unable to dispatch event to handler"

--- a/rsb-java/src/main/java/rsb/patterns/Callback.java
+++ b/rsb-java/src/main/java/rsb/patterns/Callback.java
@@ -89,12 +89,18 @@ public interface Callback {
      * Method to invoke the {@link Callback}'s functionality. This method can be
      * considered an internal implementation detail.
      *
+     * Implementing user code must not swallow interruption state. Instead, it
+     * has to be passed to the outside world.
+     *
      * @param request
      *            the request received from a {@link RemoteServer} method call
      * @return an event with the result data of a method
      * @throws UserCodeException
      *             any exception in the user code invoked by the callback
+     * @throws InterruptedException
+     *             indicates that the called action was interrupted
      */
-    Event internalInvoke(Event request) throws UserCodeException;
+    Event internalInvoke(Event request) throws UserCodeException,
+             InterruptedException;
 
 }

--- a/rsb-java/src/main/java/rsb/patterns/DataCallback.java
+++ b/rsb-java/src/main/java/rsb/patterns/DataCallback.java
@@ -53,8 +53,10 @@ public abstract class DataCallback<ReplyType, RequestType> implements Callback {
 
     // Convenience for users to throw anything
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public Event internalInvoke(final Event request) throws UserCodeException {
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException",
+            "PMD.AvoidRethrowingException"})
+    public Event internalInvoke(final Event request) throws UserCodeException,
+            InterruptedException {
         try {
             @SuppressWarnings("unchecked")
             final ReplyType result =
@@ -68,6 +70,9 @@ public abstract class DataCallback<ReplyType, RequestType> implements Callback {
                 type = result.getClass();
             }
             return new Event(type, result);
+        } catch (final InterruptedException e) {
+            // ensure that interruption is handled explicitly
+            throw e;
         } catch (final Exception e) {
             throw new UserCodeException(e);
         }
@@ -76,11 +81,17 @@ public abstract class DataCallback<ReplyType, RequestType> implements Callback {
     /**
      * This method is called to invoke the actual behavior of an exposed method.
      *
+     * Implementing user code must not swallow interruption state. Instead, it
+     * has to be passed to the outside world through an {@link
+     * InterruptedException}.
+     *
      * @param request
      *            The argument passed to the associated method by the remote
      *            caller.
      * @return A result that should be returned to the remote caller as the
      *         result of the calling the method.
+     * @throws InterruptedException
+     *             Indicates that the operation was interrupted.
      * @throws Exception
      *             Can throw anything.
      */

--- a/rsb-java/src/main/java/rsb/patterns/EventCallback.java
+++ b/rsb-java/src/main/java/rsb/patterns/EventCallback.java
@@ -39,10 +39,15 @@ public abstract class EventCallback implements Callback {
 
     // Convenience for users to throw anything
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public Event internalInvoke(final Event request) throws UserCodeException {
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException",
+            "PMD.AvoidRethrowingException"})
+    public Event internalInvoke(final Event request) throws UserCodeException,
+            InterruptedException {
         try {
             return this.invoke(request);
+        } catch (final InterruptedException e) {
+            // ensure that interruption is handled explicitly
+            throw e;
         } catch (final Exception e) {
             throw new UserCodeException(e);
         }
@@ -51,11 +56,17 @@ public abstract class EventCallback implements Callback {
     /**
      * This method is called to invoke the actual behavior of an exposed method.
      *
+     * Implementing user code must not swallow interruption state. Instead, it
+     * has to be passed to the outside world through an {@link
+     * InterruptedException}.
+     *
      * @param request
      *            The argument passed to the associated method by the remote
      *            caller.
      * @return A result that should be returned to the remote caller as the
      *         result of the calling the method.
+     * @throws InterruptedException
+     *             Indicates that the operation was interrupted.
      * @throws Exception
      *             Can throw anything.
      */

--- a/rsb-java/src/main/java/rsb/patterns/LocalMethod.java
+++ b/rsb-java/src/main/java/rsb/patterns/LocalMethod.java
@@ -105,7 +105,7 @@ class LocalMethod extends Method implements Handler {
                         new IllegalArgumentException(
                             "Null reply from callback"));
             }
-        } catch (final UserCodeException e) {
+        } catch (final UserCodeException | InterruptedException e) {
             final Throwable exception = e.getCause();
             LOG.log(Level.WARNING,
                     "Exception during method invocation in participant: {0}. "


### PR DESCRIPTION
Let handlers and callbacks throw InterruptedExceptions to ensure that participants can be deactivated while a call to handler is running.

This probably fixes https://code.cor-lab.org/issues/2774