### PR TITLE
Add a reader implementation

### DIFF
--- a/rsb-java-test/pom.xml
+++ b/rsb-java-test/pom.xml
@@ -20,6 +20,7 @@
         <test.configs>${project.basedir}/target/generated-test-config</test.configs>
         <!-- If set to true, test execution pauses shortly between each test to mitigate https://issues.apache.org/jira/browse/SUREFIRE&#45;1587 -->
         <test.sleep>false</test.sleep>
+        <jmockit.version>1.43</jmockit.version>
     </properties>
 
     <dependencies>
@@ -34,6 +35,13 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>${jmockit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -44,19 +52,20 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>java.util.logging.config.file</name>
-                            <value>${test.configs}/logging.properties</value>
-                        </property>
-                        <property>
-                            <name>rsb.test.sleep</name>
-                            <value>${test.sleep}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>
+                            ${test.configs}/logging.properties
+                        </java.util.logging.config.file>
+                        <rsb.test.sleep>
+                            ${test.sleep}
+                        </rsb.test.sleep>
+                    </systemPropertyVariables>
                     <environmentVariables>
                         <RSB_TRANSPORT_SOCKET_PORT>${socket.port}</RSB_TRANSPORT_SOCKET_PORT>
                     </environmentVariables>
+                    <argLine>
+                        @{argLine} -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+                    </argLine>
                 </configuration>
             </plugin>
 

--- a/rsb-java-test/src/test/java/rsb/FactoryTest.java
+++ b/rsb-java-test/src/test/java/rsb/FactoryTest.java
@@ -1,0 +1,106 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2018 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import rsb.config.ParticipantConfig;
+import rsb.patterns.Reader;
+
+public class FactoryTest extends RsbTestCase {
+
+    private static final Scope SOME_SCOPE = new Scope("/some/scope");
+
+    @Test
+    public void createReaderScope() throws Exception {
+        final Reader reader = Factory.getInstance().createReader(SOME_SCOPE);
+        assertNotNull(reader);
+        assertEquals(SOME_SCOPE, reader.getScope());
+        assertEquals(Factory.getInstance().getDefaultParticipantConfig(),
+                reader.getConfig());
+        assertFalse(reader.isActive());
+    }
+
+    @Test
+    public void createReaderScopeString() throws Exception {
+        final Scope scope = new Scope("/a/test");
+        final Reader reader = Factory.getInstance().createReader(
+                SOME_SCOPE.toString());
+        assertNotNull(reader);
+        assertEquals(SOME_SCOPE, reader.getScope());
+        assertEquals(Factory.getInstance().getDefaultParticipantConfig(),
+                reader.getConfig());
+        assertFalse(reader.isActive());
+    }
+
+    @Test
+    public void createReaderScopeConfig() throws Exception {
+        final ParticipantConfig config = Factory.getInstance()
+            .getDefaultParticipantConfig().copy();
+        config.getOrCreateTransport("socket").getOptions().setProperty(
+                "foo", "bar");
+        final Reader reader = Factory.getInstance().createReader(
+                SOME_SCOPE, config);
+        assertNotNull(reader);
+        assertEquals(SOME_SCOPE, reader.getScope());
+        assertEquals(config, reader.getConfig());
+        assertNotEquals(Factory.getInstance().getDefaultParticipantConfig(),
+                reader.getConfig());
+        assertFalse(reader.isActive());
+    }
+
+    @Test
+    public void createReaderArgs() throws Exception {
+        final ReaderCreateArgs args = new ReaderCreateArgs();
+        args.setScope(SOME_SCOPE);
+        final Reader reader = Factory.getInstance().createReader(args);
+        assertNotNull(reader);
+        assertEquals(SOME_SCOPE, reader.getScope());
+        assertEquals(Factory.getInstance().getDefaultParticipantConfig(),
+                reader.getConfig());
+        assertFalse(reader.isActive());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createReaderArgsNull() throws Exception {
+        final ReaderCreateArgs args = null;
+        Factory.getInstance().createReader(args);
+    }
+
+    @Test
+    public void createReaderSetsObserver() throws Exception {
+        assertNotNull(Factory.getInstance().createReader(
+                    SOME_SCOPE).getObserverManager());
+    }
+
+}

--- a/rsb-java-test/src/test/java/rsb/patterns/ReaderStateTest.java
+++ b/rsb-java-test/src/test/java/rsb/patterns/ReaderStateTest.java
@@ -1,0 +1,54 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2018 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb.patterns;
+
+import rsb.Factory;
+import rsb.Participant;
+import rsb.ReaderCreateArgs;
+import rsb.Scope;
+import rsb.ParticipantStateCheck;
+import rsb.config.ParticipantConfig;
+
+/**
+ * A {@link ParticipantStateCheck} for {@link Reader} instances.
+ *
+ * @author jwienke
+ */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public class ReaderStateTest extends ParticipantStateCheck {
+
+    @Override
+    protected Participant createParticipant(
+            final ParticipantConfig config) throws Exception {
+        return new Reader(new ReaderCreateArgs()
+                .setScope(new Scope("/some/scope"))
+                .setConfig(config), Factory.getInstance());
+    }
+
+}
+

--- a/rsb-java-test/src/test/java/rsb/patterns/ReaderTest.java
+++ b/rsb-java-test/src/test/java/rsb/patterns/ReaderTest.java
@@ -1,0 +1,133 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2018 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb.patterns;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+
+import org.junit.Test;
+
+import rsb.Factory;
+import rsb.Handler;
+import rsb.Listener;
+import rsb.ListenerCreateArgs;
+import rsb.ReaderCreateArgs;
+import rsb.RsbTestCase;
+import rsb.RSBException;
+import rsb.Scope;
+import rsb.config.ParticipantConfig;
+
+public class ReaderTest extends RsbTestCase {
+
+    @Test
+    public void listenerSetUpCorrectly(@Mocked final Factory factory,
+            @Mocked final Listener listener) throws Exception {
+        final ParticipantConfig config = new ParticipantConfig();
+        final ReaderCreateArgs args = new ReaderCreateArgs().setScope(
+                new Scope("/reader/test")).setConfig(config);
+
+        final Reader reader = new Reader(args, factory);
+
+        new Verifications() {
+            {
+                ListenerCreateArgs listenerArgs;
+                // CHECKSTYLE.OFF: InnerAssignment - required for mockit
+                factory.createListener(listenerArgs = withCapture());
+                // CHECKSTYLE.ON: InnerAssignment
+
+                assertEquals(args.getScope(), listenerArgs.getScope());
+                assertEquals(args.getConfig(), listenerArgs.getConfig());
+                assertEquals(reader, listenerArgs.getParent());
+            }
+        };
+    }
+
+    @Test
+    public void readReturnsNull(@Mocked final Factory factory)
+            throws Exception {
+        final ParticipantConfig config = new ParticipantConfig();
+        final ReaderCreateArgs args = new ReaderCreateArgs().setScope(
+                new Scope("/reader/test/nothing/here")).setConfig(config);
+
+        final Reader reader = new Reader(args, factory);
+        reader.activate();
+
+        assertNull(reader.read());
+
+        reader.deactivate();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void readIllegalBeforeActivate(@Mocked final Factory factory)
+            throws Exception {
+        final ParticipantConfig config = new ParticipantConfig();
+        final ReaderCreateArgs args = new ReaderCreateArgs().setScope(
+                new Scope("/strange/thing")).setConfig(config);
+
+        final Reader reader = new Reader(args, factory);
+        reader.read();
+    }
+
+    @Test(expected = RSBException.class)
+    public void interruptedExceptionWhileAddingHandler(
+            @Mocked final Factory factory,
+            @Mocked final Listener listener) throws Exception {
+
+        final ParticipantConfig config = new ParticipantConfig();
+        final ReaderCreateArgs args = new ReaderCreateArgs().setScope(
+                new Scope("/test/interrupt")).setConfig(config);
+
+        new Expectations() {
+            {
+                factory.createListener((ListenerCreateArgs) withNotNull());
+                result = listener;
+
+                listener.activate();
+
+                listener.addHandler((Handler) withNotNull(), true);
+                result = new InterruptedException();
+            }
+        };
+
+        try {
+            final Reader reader = new Reader(args, factory);
+            reader.activate();
+        } finally {
+            // should have been re-interrupted
+            assertTrue(Thread.currentThread().interrupted());
+            // the previous call also clears the flag such that the following
+            // tests can continue without problems.
+        }
+    }
+
+}

--- a/rsb-java/src/main/java/rsb/Factory.java
+++ b/rsb-java/src/main/java/rsb/Factory.java
@@ -43,6 +43,7 @@ import rsb.converter.DefaultConverters;
 import rsb.introspection.IntrospectionParticipantObserver;
 import rsb.introspection.LacksOsInformationException;
 import rsb.patterns.LocalServer;
+import rsb.patterns.Reader;
 import rsb.patterns.RemoteServer;
 import rsb.plugin.PluginManager;
 
@@ -476,6 +477,91 @@ public final class Factory {
                 new Listener(addConfigToArgs(args));
         listener.setObserverManager(this.observerManager);
         return listener;
+    }
+
+    /**
+     * Creates a new reader instance.
+     *
+     * @param scope
+     *            scope of the reader
+     * @return new reader
+     * @throws InitializeException
+     *             error initializing the reader
+     */
+    public Reader createReader(final Scope scope)
+            throws InitializeException {
+        return createReader(new ReaderCreateArgs().setScope(scope));
+    }
+
+    /**
+     * Creates a new reader instance.
+     *
+     * @param scope
+     *            scope of the reader
+     * @return new reader
+     * @throws InitializeException
+     *             error initializing the reader
+     */
+    public Reader createReader(final String scope)
+            throws InitializeException {
+        return createReader(new ReaderCreateArgs()
+                .setScope(new Scope(scope)));
+    }
+
+    /**
+     * Creates a new reader instance.
+     *
+     * @param scope
+     *            scope of the reader
+     * @param config
+     *            participant configuration to use
+     * @return new reader
+     * @throws InitializeException
+     *             error initializing the reader
+     */
+    public Reader createReader(final String scope,
+            final ParticipantConfig config) throws InitializeException {
+        return createReader(new ReaderCreateArgs().setScope(
+                new Scope(scope)).setConfig(config));
+    }
+
+    /**
+     * Creates a new reader instance.
+     *
+     * @param scope
+     *            scope of the reader
+     * @param config
+     *            participant configuration to use
+     * @return new reader
+     * @throws InitializeException
+     *             error initializing the reader
+     */
+    public Reader createReader(final Scope scope,
+            final ParticipantConfig config) throws InitializeException {
+        return createReader(new ReaderCreateArgs().setScope(scope)
+                .setConfig(config));
+    }
+
+    /**
+     * Creates a new reader instance.
+     *
+     * @param args
+     *            Parameter object with create arguments for the participant.
+     * @return new reader
+     * @throws InitializeException
+     *             error initializing the reader
+     * @throws IllegalArgumentException
+     *             args is <code>null</code>
+     */
+    public Reader createReader(final ReaderCreateArgs args)
+            throws InitializeException {
+        if (args == null) {
+            throw new IllegalArgumentException(
+                    "Creation arguments must not be null");
+        }
+        final Reader reader = new Reader(addConfigToArgs(args), this);
+        reader.setObserverManager(this.observerManager);
+        return reader;
     }
 
     /**

--- a/rsb-java/src/main/java/rsb/ReaderCreateArgs.java
+++ b/rsb-java/src/main/java/rsb/ReaderCreateArgs.java
@@ -1,0 +1,39 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2018 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb;
+
+/**
+ * {@link ParticipantCreateArgs} for {@link Reader} instances.
+ *
+ * @author jwienke
+ */
+public class ReaderCreateArgs extends
+        ParticipantCreateArgs<ReaderCreateArgs> {
+    // no specific parameters required here
+}
+

--- a/rsb-java/src/main/java/rsb/patterns/Reader.java
+++ b/rsb-java/src/main/java/rsb/patterns/Reader.java
@@ -1,0 +1,230 @@
+/**
+ * ============================================================
+ *
+ * This file is part of the rsb-java project
+ *
+ * Copyright (C) 2010 CoR-Lab, Bielefeld University
+ *
+ * This file may be licensed under the terms of the
+ * GNU Lesser General Public License Version 3 (the ``LGPL''),
+ * or (at your option) any later version.
+ *
+ * Software distributed under the License is distributed
+ * on an ``AS IS'' basis, WITHOUT WARRANTY OF ANY KIND, either
+ * express or implied. See the LGPL for the specific language
+ * governing rights and limitations.
+ *
+ * You should have received a copy of the LGPL along with this
+ * program. If not, go to http://www.gnu.org/licenses/lgpl.html
+ * or write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The development of this software was supported by:
+ *   CoR-Lab, Research Institute for Cognition and Robotics
+ *     Bielefeld University
+ *
+ * ============================================================
+ */
+package rsb.patterns;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import rsb.AbstractEventHandler;
+import rsb.Event;
+import rsb.Factory;
+import rsb.InitializeException;
+import rsb.Listener;
+import rsb.ListenerCreateArgs;
+import rsb.Participant;
+import rsb.ReaderCreateArgs;
+import rsb.RSBException;
+import rsb.Activatable;
+
+/**
+ * Implements synchronous event receiving as a pattern on top of the usual
+ * asynchronous participant types.
+ *
+ * Clients have to continuously poll for new events by calling the #read()
+ * method. Internally, a queue is used to buffer received events.
+ *
+ * @author jwienke
+ */
+public class Reader extends Participant {
+
+    private State state;
+    private final Listener listener;
+    private final BlockingQueue<Event> queue = new LinkedBlockingQueue<>();
+
+    private abstract class State extends Activatable.State {
+        // pull into own namespace for nice state class names
+        public Event read(final long timeout,
+                final TimeUnit unit) throws RSBException, InterruptedException {
+            throw new IllegalStateException(
+                    "Reading is only possible in active state");
+        }
+    }
+
+    private class StateInactive extends State {
+
+        @Override
+        public void activate() throws RSBException {
+            Reader.super.activate();
+            Reader.this.listener.activate();
+            try {
+                Reader.this.listener.addHandler(new AbstractEventHandler() {
+
+                    @Override
+                    public void handleEvent(final Event event) {
+                        Reader.this.queue.add(event);
+                    }
+
+                }, true);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RSBException(e);
+            }
+            Reader.this.state = new StateActive();
+        }
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
+
+    }
+
+    private class StateActive extends State {
+
+        @Override
+        public void deactivate() throws RSBException, InterruptedException {
+            Reader.super.deactivate();
+            Reader.this.state = new StateTerminal();
+            Reader.this.listener.deactivate();
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+        @Override
+        public Event read(final long timeout,
+                final TimeUnit unit) throws RSBException, InterruptedException {
+            return Reader.this.queue.poll(timeout, unit);
+        }
+    }
+
+    private class StateTerminal extends State {
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
+
+    }
+
+    /**
+     * Creates a new reader instance.
+     *
+     * @param args
+     *            Arguments for creating the participant
+     * @param factory
+     *            Factory instance used for creating the internal listener
+     * @throws InitializeException
+     *             error initializing the reader
+     */
+    public Reader(final ReaderCreateArgs args,
+            final Factory factory) throws InitializeException {
+        super(args);
+
+        this.state = new StateInactive();
+
+        final ListenerCreateArgs listenerArgs = new ListenerCreateArgs();
+        listenerArgs.setScope(args.getScope());
+        listenerArgs.setConfig(args.getConfig());
+        listenerArgs.setParent(this);
+        this.listener = factory.createListener(listenerArgs);
+    }
+
+    @Override
+    public boolean isActive() {
+        synchronized (this) {
+            return this.state.isActive();
+        }
+    }
+
+    @Override
+    public void activate() throws RSBException {
+        synchronized (this) {
+            this.state.activate();
+        }
+    }
+
+    @Override
+    public void deactivate() throws RSBException, InterruptedException {
+        synchronized (this) {
+            this.state.deactivate();
+        }
+    }
+
+    @Override
+    public Set<URI> getTransportUris() {
+        return new HashSet<URI>();
+    }
+
+    /**
+     * Read the next event without blocking.
+     *
+     * If available, returns the next event that was received.
+     *
+     * @return an event of <code>null</code> if no unread event was received
+     *         yet.
+     * @throws RSBException
+     *             reading the event failed
+     * @throws InterruptedException
+     *             interrupted while reading
+     */
+    public Event read() throws RSBException, InterruptedException {
+        return this.read(0, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Read the next event and block until one is available.
+     *
+     * Waits up to the specified amount of time for receiving the next event.
+     *
+     * @param timeout
+     *            the amount of time to wait
+     * @param unit
+     *            the unit of the amount of time to wait
+     * @return an event of <code>null</code> if no unread event was received
+     *         until timeout.
+     * @throws RSBException
+     *             reading the event failed
+     * @throws InterruptedException
+     *             interrupted while reading
+     */
+    public Event read(
+            final long timeout, final TimeUnit unit) throws RSBException,
+           InterruptedException {
+        synchronized (this) {
+            return this.state.read(timeout, unit);
+        }
+    }
+
+    @Override
+    public Class<?> getDataType() {
+        return Object.class;
+    }
+
+    @Override
+    public String getKind() {
+        return "reader";
+    }
+
+}


### PR DESCRIPTION
This will fix #13.

The implementation of this feature adds a mock testing framework (mockit) to the dependencies of the test framework. We can probably make use of this technique in more places for better test verifications. mockit seems to be a good candidate atm.