### PR TITLE
Fix configuration key for loaded plugins

### DIFF
--- a/rsb-java/src/main/java/rsb/Factory.java
+++ b/rsb-java/src/main/java/rsb/Factory.java
@@ -74,7 +74,7 @@ public final class Factory {
     /**
      * Configuration key for plugins to load.
      */
-    private static final String PLUGIN_LOAD_KEY = "plugin.java.load";
+    private static final String PLUGIN_LOAD_KEY = "plugins.java.load";
 
     /**
      * The singleton instance.


### PR DESCRIPTION
Be consistent with the other implementations and use `pluginS.java.load` for specifying which plugins to load.